### PR TITLE
Add dynamic font size picker example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,12 +6,14 @@ import {
   AvatarCustomizedPickerBlockExample,
   CompareWithNativeIOSBlockExample,
   SimplePickerBlockExample,
+  FontSizePickerBlockExample,
 } from './components/example-blocks';
 
 const App = () => {
   return (
     <ScrollView contentContainerStyle={styles.contentContainer}>
       <SimplePickerBlockExample />
+      <FontSizePickerBlockExample />
       <AvatarCustomizedPickerBlockExample />
       <CompareWithNativeIOSBlockExample />
       <Box height={100} />

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItem.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItem.tsx
@@ -1,0 +1,20 @@
+import React, {memo} from 'react';
+import {Animated, StyleSheet, Text} from 'react-native';
+import {usePickerItemHeight, type RenderItemProps} from '@quidone/react-native-wheel-picker';
+
+const AnimatedText = Animated.createAnimatedComponent(Text);
+
+const PickerItem = ({item: {value, label}, itemTextStyle}: RenderItemProps<any>) => {
+  const height = usePickerItemHeight();
+  return (
+    <AnimatedText style={[styles.text, {lineHeight: height}, itemTextStyle]}>
+      {label ?? value}
+    </AnimatedText>
+  );
+};
+
+const styles = StyleSheet.create({
+  text: {textAlign: 'center', fontSize: 20},
+});
+
+export default memo(PickerItem);

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItemContainer.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItemContainer.tsx
@@ -1,0 +1,67 @@
+import React, {memo, useMemo} from 'react';
+import {Animated} from 'react-native';
+import {
+  PickerItem,
+  RenderItemContainerProps,
+  usePickerItemHeight,
+  useScrollContentOffset,
+} from '@quidone/react-native-wheel-picker';
+
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 1.2;
+const STEP_DECREASE = 0.2;
+
+const PickerItemContainer = ({
+  index,
+  item,
+  faces,
+  renderItem,
+  itemTextStyle,
+}: RenderItemContainerProps<PickerItem<any>>) => {
+  const offset = useScrollContentOffset();
+  const height = usePickerItemHeight();
+
+  const inputRange = useMemo(() => faces.map((f) => height * (index + f.index)), [faces, height, index]);
+
+  const {opacity, rotateX, translateY, scale} = useMemo(() => {
+    const getScale = (faceIndex: number) =>
+      Math.max(MIN_SCALE, MAX_SCALE - STEP_DECREASE * Math.abs(faceIndex));
+
+    return {
+      opacity: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => x.opacity),
+        extrapolate: 'clamp',
+      }),
+      rotateX: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => `${x.deg}deg`),
+        extrapolate: 'extend',
+      }),
+      translateY: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => x.offsetY),
+        extrapolate: 'extend',
+      }),
+      scale: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => getScale(x.index)),
+        extrapolate: 'clamp',
+      }),
+    };
+  }, [faces, height, index, offset, inputRange]);
+
+  return (
+    <Animated.View
+      style={{
+        height,
+        opacity,
+        transform: [{translateY}, {rotateX}, {perspective: 1000}],
+      }}
+    >
+      {renderItem({item, index, itemTextStyle: [itemTextStyle, {transform: [{scale}]}]})}
+    </Animated.View>
+  );
+};
+
+export default memo(PickerItemContainer);

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/index.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/index.tsx
@@ -1,0 +1,53 @@
+import React, {memo, useCallback, useState} from 'react';
+import WheelPicker, {
+  PickerItem,
+  RenderItem,
+  RenderItemContainer,
+  type ValueChangedEvent,
+} from '@quidone/react-native-wheel-picker';
+import {useInit} from '@rozhkov/react-useful-hooks';
+import {withExamplePickerConfig} from '../../../picker-config';
+import {Header} from '../../base';
+import PickerItemComponent from './PickerItem';
+import PickerItemContainer from './PickerItemContainer';
+
+const ExampleWheelPicker = withExamplePickerConfig(WheelPicker);
+
+const createPickerItem = (index: number): PickerItem<number> => ({
+  value: index,
+  label: index.toString(),
+});
+
+const renderItem: RenderItem<PickerItem<number>> = (props) => (
+  <PickerItemComponent {...props} />
+);
+const renderItemContainer: RenderItemContainer<PickerItem<number>> = (props) => (
+  <PickerItemContainer {...props} />
+);
+
+const FontSizePicker = () => {
+  const data = useInit(() => [...Array(100).keys()].map(createPickerItem));
+  const [value, setValue] = useState(0);
+
+  const onValueChanged = useCallback(
+    ({item: {value: val}}: ValueChangedEvent<PickerItem<number>>) => {
+      setValue(val);
+    },
+    [],
+  );
+
+  return (
+    <>
+      <Header title={'Font Size Picker'} />
+      <ExampleWheelPicker
+        data={data}
+        value={value}
+        onValueChanged={onValueChanged}
+        renderItem={renderItem}
+        renderItemContainer={renderItemContainer}
+      />
+    </>
+  );
+};
+
+export default memo(FontSizePicker);

--- a/example/src/components/example-blocks/index.ts
+++ b/example/src/components/example-blocks/index.ts
@@ -1,3 +1,5 @@
 export {default as SimplePickerBlockExample} from './SimplePickerBlockExample';
 export {default as AvatarCustomizedPickerBlockExample} from './AvatarCustomizedPickerBlockExample';
 export {default as CompareWithNativeIOSBlockExample} from './CompareWithNativeIOSBlockExample';
+
+export {default as FontSizePickerBlockExample} from "./FontSizePickerBlockExample";

--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -17,6 +17,39 @@ exports[`WheelPicker should match snapshot 1`] = `
   }
   testID="wheel-picker"
 >
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#000",
+            "borderRadius": 8,
+            "opacity": 0.05,
+          },
+          Object {
+            "height": 48,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
   <RCTScrollView
     collapsable={false}
     contentContainerStyle={
@@ -99,38 +132,5 @@ exports[`WheelPicker should match snapshot 1`] = `
       </View>
     </View>
   </RCTScrollView>
-  <View
-    pointerEvents="none"
-    style={
-      Array [
-        Object {
-          "alignItems": "center",
-          "bottom": 0,
-          "justifyContent": "center",
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-      ]
-    }
-  >
-    <View
-      style={
-        Array [
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#000",
-            "borderRadius": 8,
-            "opacity": 0.05,
-          },
-          Object {
-            "height": 48,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
 </View>
 `;


### PR DESCRIPTION
## Summary
- add new FontSizePickerBlockExample for gradually changing font sizes
- show the new picker in the sample app
- update snapshot tests
- scale items using transform instead of animating `fontSize`

## Testing
- `yarn test:run`

------
https://chatgpt.com/codex/tasks/task_e_68458bebb668832fbf4a2159e24f89d2