### PR TITLE
Add adjustable overlay for scaled picker

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,12 +6,14 @@ import {
   AvatarCustomizedPickerBlockExample,
   CompareWithNativeIOSBlockExample,
   SimplePickerBlockExample,
+  FontSizePickerBlockExample,
 } from './components/example-blocks';
 
 const App = () => {
   return (
     <ScrollView contentContainerStyle={styles.contentContainer}>
       <SimplePickerBlockExample />
+      <FontSizePickerBlockExample />
       <AvatarCustomizedPickerBlockExample />
       <CompareWithNativeIOSBlockExample />
       <Box height={100} />

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/Overlay.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/Overlay.tsx
@@ -1,0 +1,33 @@
+import React, {memo} from 'react';
+import {StyleSheet, View} from 'react-native';
+import type {RenderOverlayProps} from '@quidone/react-native-wheel-picker';
+import {MAX_SCALE} from './constants';
+
+type Props = RenderOverlayProps & {
+  lineHeight?: number;
+};
+
+const Overlay = ({itemHeight, overlayItemStyle, lineHeight}: Props) => {
+  const height = lineHeight ?? itemHeight * MAX_SCALE;
+  return (
+    <View style={styles.overlayContainer} pointerEvents="none">
+      <View style={[styles.selection, {height}, overlayItemStyle]} />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  overlayContainer: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  selection: {
+    opacity: 0.05,
+    backgroundColor: '#000',
+    borderRadius: 8,
+    alignSelf: 'stretch',
+  },
+});
+
+export default memo(Overlay);

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItem.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItem.tsx
@@ -1,0 +1,18 @@
+import React, {memo} from 'react';
+import {StyleSheet, Text} from 'react-native';
+import {usePickerItemHeight, type RenderItemProps} from '@quidone/react-native-wheel-picker';
+
+const PickerItem = ({item: {value, label}, itemTextStyle}: RenderItemProps<any>) => {
+  const height = usePickerItemHeight();
+  return (
+    <Text style={[styles.text, {lineHeight: height}, itemTextStyle]}>
+      {label ?? value}
+    </Text>
+  );
+};
+
+const styles = StyleSheet.create({
+  text: {textAlign: 'center', fontSize: 20},
+});
+
+export default memo(PickerItem);

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItemContainer.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/PickerItemContainer.tsx
@@ -1,0 +1,64 @@
+import React, {memo, useMemo} from 'react';
+import {Animated} from 'react-native';
+import {
+  PickerItem,
+  RenderItemContainerProps,
+  usePickerItemHeight,
+  useScrollContentOffset,
+} from '@quidone/react-native-wheel-picker';
+import {MIN_SCALE, MAX_SCALE, STEP_DECREASE} from './constants';
+
+const PickerItemContainer = ({
+  index,
+  item,
+  faces,
+  renderItem,
+  itemTextStyle,
+}: RenderItemContainerProps<PickerItem<any>>) => {
+  const offset = useScrollContentOffset();
+  const height = usePickerItemHeight();
+
+  const inputRange = useMemo(() => faces.map((f) => height * (index + f.index)), [faces, height, index]);
+
+  const {opacity, rotateX, translateY, scale} = useMemo(() => {
+    const getScale = (faceIndex: number) =>
+      Math.max(MIN_SCALE, MAX_SCALE - STEP_DECREASE * Math.abs(faceIndex));
+
+    return {
+      opacity: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => x.opacity),
+        extrapolate: 'clamp',
+      }),
+      rotateX: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => `${x.deg}deg`),
+        extrapolate: 'extend',
+      }),
+      translateY: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => x.offsetY),
+        extrapolate: 'extend',
+      }),
+      scale: offset.interpolate({
+        inputRange,
+        outputRange: faces.map((x) => getScale(x.index)),
+        extrapolate: 'clamp',
+      }),
+    };
+  }, [faces, height, index, offset, inputRange]);
+
+  return (
+    <Animated.View
+      style={{
+        height,
+        opacity,
+        transform: [{translateY}, {rotateX}, {perspective: 1000}, {scale}],
+      }}
+    >
+      {renderItem({item, index, itemTextStyle})}
+    </Animated.View>
+  );
+};
+
+export default memo(PickerItemContainer);

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/constants.ts
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/constants.ts
@@ -1,0 +1,3 @@
+export const MIN_SCALE = 0.5;
+export const MAX_SCALE = 1.2;
+export const STEP_DECREASE = 0.2;

--- a/example/src/components/example-blocks/FontSizePickerBlockExample/index.tsx
+++ b/example/src/components/example-blocks/FontSizePickerBlockExample/index.tsx
@@ -1,0 +1,63 @@
+import React, {memo, useCallback, useState} from 'react';
+import WheelPicker, {
+  PickerItem,
+  RenderItem,
+  RenderItemContainer,
+  RenderOverlay,
+  type ValueChangedEvent,
+} from '@quidone/react-native-wheel-picker';
+import {useInit} from '@rozhkov/react-useful-hooks';
+import {withExamplePickerConfig} from '../../../picker-config';
+import {Header} from '../../base';
+import PickerItemComponent from './PickerItem';
+import PickerItemContainer from './PickerItemContainer';
+import Overlay from './Overlay';
+
+// Set this to override the overlay line height. Leave undefined for automatic
+// calculation based on the maximum scale.
+const LINE_HEIGHT: number | undefined = undefined;
+
+const ExampleWheelPicker = withExamplePickerConfig(WheelPicker);
+
+const createPickerItem = (index: number): PickerItem<number> => ({
+  value: index,
+  label: index.toString(),
+});
+
+const renderItem: RenderItem<PickerItem<number>> = (props) => (
+  <PickerItemComponent {...props} />
+);
+const renderItemContainer: RenderItemContainer<PickerItem<number>> = (props) => (
+  <PickerItemContainer {...props} />
+);
+const renderOverlay: RenderOverlay = (props) => (
+  <Overlay {...props} lineHeight={LINE_HEIGHT} />
+);
+
+const FontSizePicker = () => {
+  const data = useInit(() => [...Array(100).keys()].map(createPickerItem));
+  const [value, setValue] = useState(0);
+
+  const onValueChanged = useCallback(
+    ({item: {value: val}}: ValueChangedEvent<PickerItem<number>>) => {
+      setValue(val);
+    },
+    [],
+  );
+
+  return (
+    <>
+      <Header title={'Font Size Picker'} />
+      <ExampleWheelPicker
+        data={data}
+        value={value}
+        onValueChanged={onValueChanged}
+        renderItem={renderItem}
+        renderItemContainer={renderItemContainer}
+        renderOverlay={renderOverlay}
+      />
+    </>
+  );
+};
+
+export default memo(FontSizePicker);

--- a/example/src/components/example-blocks/index.ts
+++ b/example/src/components/example-blocks/index.ts
@@ -1,3 +1,5 @@
 export {default as SimplePickerBlockExample} from './SimplePickerBlockExample';
 export {default as AvatarCustomizedPickerBlockExample} from './AvatarCustomizedPickerBlockExample';
 export {default as CompareWithNativeIOSBlockExample} from './CompareWithNativeIOSBlockExample';
+
+export {default as FontSizePickerBlockExample} from './FontSizePickerBlockExample';

--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -17,6 +17,39 @@ exports[`WheelPicker should match snapshot 1`] = `
   }
   testID="wheel-picker"
 >
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#000",
+            "borderRadius": 8,
+            "opacity": 0.05,
+          },
+          Object {
+            "height": 48,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
   <RCTScrollView
     collapsable={false}
     contentContainerStyle={
@@ -99,38 +132,5 @@ exports[`WheelPicker should match snapshot 1`] = `
       </View>
     </View>
   </RCTScrollView>
-  <View
-    pointerEvents="none"
-    style={
-      Array [
-        Object {
-          "alignItems": "center",
-          "bottom": 0,
-          "justifyContent": "center",
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-      ]
-    }
-  >
-    <View
-      style={
-        Array [
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#000",
-            "borderRadius": 8,
-            "opacity": 0.05,
-          },
-          Object {
-            "height": 48,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
 </View>
 `;


### PR DESCRIPTION
## Summary
- allow customizing overlay line height when picker items are scaled
- scale picker items via container transform instead of animating font size
- include new overlay component in FontSizePickerBlockExample

## Testing
- `yarn test:run`

------
https://chatgpt.com/codex/tasks/task_e_68458bebb668832fbf4a2159e24f89d2