### PR TITLE
feat: add scaling effect to wheel items

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -6,12 +6,14 @@ import {
   AvatarCustomizedPickerBlockExample,
   CompareWithNativeIOSBlockExample,
   SimplePickerBlockExample,
+  ScaledPickerBlockExample,
 } from './components/example-blocks';
 
 const App = () => {
   return (
     <ScrollView contentContainerStyle={styles.contentContainer}>
       <SimplePickerBlockExample />
+      <ScaledPickerBlockExample />
       <AvatarCustomizedPickerBlockExample />
       <CompareWithNativeIOSBlockExample />
       <Box height={100} />

--- a/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
+++ b/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
@@ -1,0 +1,37 @@
+import React, {useCallback, useState} from 'react';
+import WheelPicker, {PickerItem, type ValueChangedEvent} from '@quidone/react-native-wheel-picker';
+import {useInit} from '@rozhkov/react-useful-hooks';
+import {withExamplePickerConfig} from '../../picker-config';
+import {Header} from '../base';
+
+const ExampleWheelPicker = withExamplePickerConfig(WheelPicker);
+const createPickerItem = (index: number): PickerItem<number> => ({
+  value: index,
+  label: index.toString(),
+});
+
+const ScaledPicker = () => {
+  const data = useInit(() => [...Array(100).keys()].map(createPickerItem));
+  const [value, setValue] = useState(0);
+
+  const onValueChanged = useCallback(
+    ({item: {value: val}}: ValueChangedEvent<PickerItem<number>>) => {
+      setValue(val);
+    },
+    [],
+  );
+
+  return (
+    <>
+      <Header title={'Scaled Picker'} />
+      <ExampleWheelPicker
+        data={data}
+        value={value}
+        onValueChanged={onValueChanged}
+        width={100}
+      />
+    </>
+  );
+};
+
+export default ScaledPicker;

--- a/example/src/components/example-blocks/index.ts
+++ b/example/src/components/example-blocks/index.ts
@@ -1,3 +1,4 @@
 export {default as SimplePickerBlockExample} from './SimplePickerBlockExample';
 export {default as AvatarCustomizedPickerBlockExample} from './AvatarCustomizedPickerBlockExample';
 export {default as CompareWithNativeIOSBlockExample} from './CompareWithNativeIOSBlockExample';
+export {default as ScaledPickerBlockExample} from './ScaledPickerBlockExample';

--- a/src/base/item/PickerItem.tsx
+++ b/src/base/item/PickerItem.tsx
@@ -1,5 +1,5 @@
 import React, {memo} from 'react';
-import {StyleProp, StyleSheet, Text, TextStyle} from 'react-native';
+import {Animated, StyleProp, StyleSheet, TextStyle} from 'react-native';
 import {usePickerItemHeight} from '../contexts/PickerItemHeightContext';
 
 type PickerItemProps = {
@@ -12,9 +12,9 @@ const PickerItem = ({value, label, itemTextStyle}: PickerItemProps) => {
   const height = usePickerItemHeight();
 
   return (
-    <Text style={[styles.root, {lineHeight: height}, itemTextStyle]}>
+    <Animated.Text style={[styles.root, {lineHeight: height}, itemTextStyle]}>
       {label ?? value}
-    </Text>
+    </Animated.Text>
   );
 };
 

--- a/src/base/item/PickerItemContainer.tsx
+++ b/src/base/item/PickerItemContainer.tsx
@@ -44,6 +44,25 @@ const PickerItemContainer = ({
     };
   }, [faces, height, index, offset]);
 
+  const {fontSize, lineHeight} = useMemo(() => {
+    const getScale = (i: number) => {
+      const map: Record<number, number> = {0: 1, 1: 0.8, 2: 0.6, 3: 0.4};
+      return map[i] ?? 0.4;
+    };
+
+    const inputRange = faces.map((f) => height * (index + f.index));
+    const outputRange = faces.map((f) => getScale(Math.abs(f.index)));
+    const scale = offset.interpolate({
+      inputRange,
+      outputRange,
+      extrapolate: 'clamp',
+    });
+    return {
+      fontSize: Animated.multiply(scale, 20),
+      lineHeight: Animated.multiply(scale, height),
+    };
+  }, [faces, height, index, offset]);
+
   return (
     <Animated.View
       style={[
@@ -58,7 +77,11 @@ const PickerItemContainer = ({
         },
       ]}
     >
-      {renderItem({item, index, itemTextStyle})}
+      {renderItem({
+        item,
+        index,
+        itemTextStyle: [itemTextStyle, {fontSize, lineHeight}] as any,
+      })}
     </Animated.View>
   );
 };


### PR DESCRIPTION
## Summary
- scale picker items based on distance from center
- switch default picker item to `Animated.Text`
- add ScaledPickerBlockExample to showcase the new behavior

## Testing
- `npx tsc -p tsconfig.build.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6845d84e4abc832f8b100e06cd5de5e7