### PR TITLE
Adjust offsets on scaled picker

### DIFF
--- a/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
+++ b/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
@@ -1,17 +1,23 @@
 import React, {useCallback, useState} from 'react';
 import WheelPicker, {
   PickerItem,
+  RenderItemContainer,
   type ValueChangedEvent,
 } from '@quidone/react-native-wheel-picker';
 import {useInit} from '@rozhkov/react-useful-hooks';
 import {withExamplePickerConfig} from '../../picker-config';
 import {Header} from '../base';
+import PickerItemContainer from './ScaledPickerBlockExample/PickerItemContainer';
 
 const ExampleWheelPicker = withExamplePickerConfig(WheelPicker);
 const createPickerItem = (index: number): PickerItem<number> => ({
   value: index,
   label: index.toString(),
 });
+
+const renderItemContainer: RenderItemContainer<PickerItem<any>> = (props) => (
+  <PickerItemContainer {...props} />
+);
 
 const ScaledPicker = () => {
   const data = useInit(() => [...Array(100).keys()].map(createPickerItem));
@@ -41,6 +47,7 @@ const ScaledPicker = () => {
           borderColor: '#0000FF',
           borderRadius: 128,
         }}
+        renderItemContainer={renderItemContainer}
         value={value}
         onValueChanged={onValueChanged}
         width={300}

--- a/example/src/components/example-blocks/ScaledPickerBlockExample/PickerItemContainer.tsx
+++ b/example/src/components/example-blocks/ScaledPickerBlockExample/PickerItemContainer.tsx
@@ -1,0 +1,68 @@
+import React, {memo, useMemo} from 'react';
+import {Animated} from 'react-native';
+import {
+  PickerItem,
+  RenderItemContainerProps,
+  usePickerItemHeight,
+  useScrollContentOffset,
+} from '@quidone/react-native-wheel-picker';
+
+const OFFSET_FACTOR = 0.5;
+
+const PickerItemContainer = ({
+  index,
+  item,
+  faces,
+  renderItem,
+  itemTextStyle,
+}: RenderItemContainerProps<PickerItem<any>>) => {
+  const offset = useScrollContentOffset();
+  const height = usePickerItemHeight();
+
+  const inputRange = useMemo(() => faces.map(f => height * (index + f.index)), [faces, height, index]);
+
+  const {opacity, rotateX, translateY, scale} = useMemo(() => {
+    const getScale = (i: number) => {
+      const map: Record<number, number> = {0: 1, 1: 0.6, 2: 0.3};
+      return map[i] ?? 0.3;
+    };
+
+    return {
+      opacity: offset.interpolate({
+        inputRange,
+        outputRange: faces.map(x => x.opacity),
+        extrapolate: 'clamp',
+      }),
+      rotateX: offset.interpolate({
+        inputRange,
+        outputRange: faces.map(x => `${x.deg}deg`),
+        extrapolate: 'extend',
+      }),
+      translateY: offset.interpolate({
+        inputRange,
+        outputRange: faces.map(x => x.offsetY * OFFSET_FACTOR),
+        extrapolate: 'extend',
+      }),
+      scale: offset.interpolate({
+        inputRange,
+        outputRange: faces.map(f => getScale(Math.abs(f.index))),
+        extrapolate: 'clamp',
+      }),
+    };
+  }, [faces, offset, inputRange]);
+
+  return (
+    <Animated.View
+      style={[
+        {
+          height,
+          opacity,
+          transform: [{translateY}, {rotateX}, {scale}, {perspective: 1000}],
+        },
+      ]}>
+      {renderItem({item, index, itemTextStyle})}
+    </Animated.View>
+  );
+};
+
+export default memo(PickerItemContainer);

--- a/example/src/components/example-blocks/ScaledPickerBlockExample/PickerItemContainer.tsx
+++ b/example/src/components/example-blocks/ScaledPickerBlockExample/PickerItemContainer.tsx
@@ -44,7 +44,9 @@ const PickerItemContainer = ({
       }),
       translateY: offset.interpolate({
         inputRange,
-        outputRange: faces.map((f, i) => f.offsetY - corrections[i]!),
+        outputRange: faces.map(
+          (f, i) => f.offsetY - corrections[i]! * Math.sign(f.offsetY),
+        ),
         extrapolate: 'extend',
       }),
       scale: offset.interpolate({


### PR DESCRIPTION
## Summary
- add custom PickerItemContainer for the scaled picker example
- apply the container in the scaled picker demo to move items closer together

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e1e60ee0832fb40669e67e5678fc