### PR TITLE
Fix scaling centering

### DIFF
--- a/src/base/item/PickerItemContainer.tsx
+++ b/src/base/item/PickerItemContainer.tsx
@@ -66,15 +66,17 @@ const PickerItemContainer = ({
           height,
           opacity,
           transform: [
-            {translateY}, // first translateY, then rotateX for correct transformation.
+            // first translateY, then rotateX for correct transformation.
+            {translateY},
             {rotateX},
-            {scale},
             {perspective: 1000}, // without this line this Animation will not render on Android https://reactnative.dev/docs/animations#bear-in-mind
           ],
         },
       ]}
     >
-      {renderItem({item, index, itemTextStyle})}
+      <Animated.View style={{transform: [{scale}]}}>
+        {renderItem({item, index, itemTextStyle})}
+      </Animated.View>
     </Animated.View>
   );
 };


### PR DESCRIPTION
## Summary
- keep translation unaffected by scaling so non-selected items remain centered

## Testing
- `yarn lint:check` *(fails: Couldn't find the node_modules state file)*

------
https://chatgpt.com/codex/tasks/task_e_6845e8979754832f9b03453ffeab577e