### PR TITLE
Fix scaled picker vertical spacing

### DIFF
--- a/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
+++ b/example/src/components/example-blocks/ScaledPickerBlockExample.tsx
@@ -41,6 +41,7 @@ const ScaledPicker = () => {
           borderColor: '#0000FF',
           borderRadius: 128,
         }}
+        style={{marginVertical: -90}}
         value={value}
         onValueChanged={onValueChanged}
         width={300}

--- a/src/__tests__/__snapshots__/index.test.tsx.snap
+++ b/src/__tests__/__snapshots__/index.test.tsx.snap
@@ -17,6 +17,39 @@ exports[`WheelPicker should match snapshot 1`] = `
   }
   testID="wheel-picker"
 >
+  <View
+    pointerEvents="none"
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "bottom": 0,
+          "justifyContent": "center",
+          "left": 0,
+          "position": "absolute",
+          "right": 0,
+          "top": 0,
+        },
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignSelf": "stretch",
+            "backgroundColor": "#000",
+            "borderRadius": 8,
+            "opacity": 0.05,
+          },
+          Object {
+            "height": 48,
+          },
+          undefined,
+        ]
+      }
+    />
+  </View>
   <RCTScrollView
     collapsable={false}
     contentContainerStyle={
@@ -80,57 +113,37 @@ exports[`WheelPicker should match snapshot 1`] = `
           }
         }
       >
-        <Text
+        <View
+          collapsable={false}
           style={
-            Array [
-              Object {
-                "fontSize": 20,
-                "textAlign": "center",
-              },
-              Object {
-                "lineHeight": 48,
-              },
-              undefined,
-            ]
+            Object {
+              "transform": Array [
+                Object {
+                  "scale": 1,
+                },
+              ],
+            }
           }
         >
-          Item 1
-        </Text>
+          <Text
+            style={
+              Array [
+                Object {
+                  "fontSize": 20,
+                  "textAlign": "center",
+                },
+                Object {
+                  "lineHeight": 48,
+                },
+                undefined,
+              ]
+            }
+          >
+            Item 1
+          </Text>
+        </View>
       </View>
     </View>
   </RCTScrollView>
-  <View
-    pointerEvents="none"
-    style={
-      Array [
-        Object {
-          "alignItems": "center",
-          "bottom": 0,
-          "justifyContent": "center",
-          "left": 0,
-          "position": "absolute",
-          "right": 0,
-          "top": 0,
-        },
-      ]
-    }
-  >
-    <View
-      style={
-        Array [
-          Object {
-            "alignSelf": "stretch",
-            "backgroundColor": "#000",
-            "borderRadius": 8,
-            "opacity": 0.05,
-          },
-          Object {
-            "height": 48,
-          },
-          undefined,
-        ]
-      }
-    />
-  </View>
 </View>
 `;


### PR DESCRIPTION
## Summary
- tweak scaled picker example to remove extra margin
- update snapshots

## Testing
- `yarn test:run -u`

------
https://chatgpt.com/codex/tasks/task_e_6845f2123378832f8d838729fdcd4b97